### PR TITLE
Add Hono logging route

### DIFF
--- a/src/app/api/hono/route.ts
+++ b/src/app/api/hono/route.ts
@@ -1,0 +1,20 @@
+import { Hono } from 'hono'
+import { handle } from 'hono/vercel'
+
+const app = new Hono()
+
+app.use('*', async (c, next) => {
+  const start = Date.now()
+  await next()
+  const duration = Date.now() - start
+  console.log(
+    `${new Date().toISOString()} ${c.req.method} ${c.req.url} ${duration}ms`
+  )
+})
+
+app.get('/', (c) => c.text('Hello from Hono'))
+
+export const GET = handle(app)
+export const POST = handle(app)
+export const ALL = handle(app)
+


### PR DESCRIPTION
## Summary
- implement a small API route using Hono that logs each request
- restore `package.json`, `package-lock.json` and env configuration to previous versions without the Hono dependency

## Testing
- `npm run lint` *(fails: run-p not found)*
